### PR TITLE
Supported locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 
 language: java
 
-jdk: oraclejdk8
+jdk:
+  - oraclejdk7
+  - oraclejdk8
 
 node_js: "0.12"
 

--- a/core/src/it/java/org/seedstack/i18n/ExportDataIT.java
+++ b/core/src/it/java/org/seedstack/i18n/ExportDataIT.java
@@ -27,7 +27,6 @@ import java.io.ByteArrayOutputStream;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com
- *         Date: 14/03/14
  */
 @JpaUnit("seed-i18n-domain")
 @Transactional

--- a/core/src/it/java/org/seedstack/i18n/KeyJpaRepositoryIT.java
+++ b/core/src/it/java/org/seedstack/i18n/KeyJpaRepositoryIT.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * @author pierre.thirouin@ext.mpsa.com Date: 20/11/13
+ * @author pierre.thirouin@ext.mpsa.com
  */
 @JpaUnit("seed-i18n-domain")
 @Transactional

--- a/core/src/it/java/org/seedstack/i18n/LocaleServiceIT.java
+++ b/core/src/it/java/org/seedstack/i18n/LocaleServiceIT.java
@@ -7,15 +7,14 @@
  */
 package org.seedstack.i18n;
 
-import org.seedstack.i18n.LocaleService;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.seedstack.jpa.JpaUnit;
 import org.seedstack.seed.Logging;
 import org.seedstack.seed.it.SeedITRunner;
-import org.seedstack.jpa.JpaUnit;
 import org.seedstack.seed.transaction.Transactional;
 import org.slf4j.Logger;
 
@@ -24,7 +23,6 @@ import java.util.Set;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com
- * Date: 05/12/13
  */
 @JpaUnit("seed-i18n-domain")
 @Transactional

--- a/core/src/it/java/org/seedstack/i18n/LocalizationServiceFallbackIT.java
+++ b/core/src/it/java/org/seedstack/i18n/LocalizationServiceFallbackIT.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com
- *         Date: 25/06/2014
  */
 @JpaUnit("seed-i18n-domain")
 @Transactional

--- a/core/src/it/java/org/seedstack/i18n/LocalizationServiceIT.java
+++ b/core/src/it/java/org/seedstack/i18n/LocalizationServiceIT.java
@@ -27,7 +27,6 @@ import java.util.Set;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com
- * Date: 05/12/13
  */
 @JpaUnit("seed-i18n-domain")
 @Transactional

--- a/core/src/it/java/org/seedstack/i18n/TranslationServiceIT.java
+++ b/core/src/it/java/org/seedstack/i18n/TranslationServiceIT.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com
- * Date: 05/12/13
  */
 @JpaUnit("seed-i18n-domain")
 @Transactional

--- a/core/src/main/java/org/seedstack/i18n/internal/I18nCacheLoader.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/I18nCacheLoader.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com
- *         Date: 28/05/2014
  */
 public class I18nCacheLoader extends CacheLoader<String, Map<String, String>> {
 

--- a/core/src/main/java/org/seedstack/i18n/internal/I18nCacheModule.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/I18nCacheModule.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com
- *         Date: 28/05/2014
  */
 @Install
 public class I18nCacheModule extends PrivateModule {

--- a/core/src/main/java/org/seedstack/i18n/internal/I18nCacheProvider.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/I18nCacheProvider.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com
- *         Date: 28/05/2014
  */
 public class I18nCacheProvider implements Provider<LoadingCache<String, Map<String, String>>> {
 

--- a/core/src/main/java/org/seedstack/i18n/internal/domain/model/locale/LocaleCodeSpecification.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/domain/model/locale/LocaleCodeSpecification.java
@@ -12,13 +12,13 @@ import org.kametic.specifications.AbstractSpecification;
 import java.util.regex.Pattern;
 
 /**
- * Verifies that the locale code is not null or empty and only contains letters or "-".
+ * Verifies that the locale code is not null or empty and only contains letters or "-" and "#".
  *
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
  */
 public class LocaleCodeSpecification extends AbstractSpecification<String> {
 
-    public static final String LOCALE_CODE_PATTERN = "(?i)[a-z\\-]*";
+    public static final String LOCALE_CODE_PATTERN = "(?i)[a-z\\-#]*";
     public static final String MESSAGE = "The locale should not be null or empty and should only contains letters or \"-\", but \"%s\" was found.";
 
     public static void assertCode(String locale) {

--- a/core/src/main/java/org/seedstack/i18n/internal/domain/model/locale/LocaleFactory.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/domain/model/locale/LocaleFactory.java
@@ -39,4 +39,6 @@ public interface LocaleFactory extends GenericFactory<Locale> {
      * @return the locale
      */
     Locale createFromLanguageAndRegion(String language, String region);
+
+    Locale createFromLocale(java.util.Locale locale);
 }

--- a/core/src/main/java/org/seedstack/i18n/internal/domain/model/locale/LocaleFactoryDefault.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/domain/model/locale/LocaleFactoryDefault.java
@@ -43,17 +43,16 @@ public class LocaleFactoryDefault extends BaseFactory<Locale> implements LocaleF
             case 2:
                 locale = new java.util.Locale(localeFragments[0], localeFragments[1]);
                 break;
-            case 3:
+            default:
                 locale = new java.util.Locale(localeFragments[0], localeFragments[1], localeFragments[2]);
                 break;
-            default:
-                throw new IllegalArgumentException("Unrecognized locale format: " + localeCode);
         }
 
         return this.createFromLocale(locale);
     }
 
-    private Locale createFromLocale(java.util.Locale locale) {
+    @Override
+    public Locale createFromLocale(java.util.Locale locale) {
         String normalizedLocaleCode = Locale.formatLocaleCode(locale.toString());
         String nativeLanguageName = locale.getDisplayName(locale);
         String englishLanguageName = locale.getDisplayName(new java.util.Locale(ENGLISH.toString()));

--- a/core/src/main/java/org/seedstack/i18n/internal/infrastructure/jpa/LocaleJpaRepository.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/infrastructure/jpa/LocaleJpaRepository.java
@@ -7,11 +7,8 @@
  */
 package org.seedstack.i18n.internal.infrastructure.jpa;
 
-import com.google.common.base.Preconditions;
 import org.seedstack.i18n.internal.domain.model.locale.Locale;
 import org.seedstack.i18n.internal.domain.model.locale.LocaleRepository;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
 import org.seedstack.jpa.BaseJpaRepository;
 
 import javax.persistence.NoResultException;
@@ -22,7 +19,6 @@ import java.util.List;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com
- *         Date: 13/05/2014
  */
 public class LocaleJpaRepository extends BaseJpaRepository<Locale, String> implements LocaleRepository {
 

--- a/core/src/main/java/org/seedstack/i18n/internal/infrastructure/service/ICULocaleService.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/infrastructure/service/ICULocaleService.java
@@ -15,6 +15,8 @@ import org.seedstack.i18n.LocaleService;
 import org.seedstack.i18n.internal.domain.model.locale.Locale;
 import org.seedstack.i18n.internal.domain.model.locale.LocaleFactory;
 import org.seedstack.i18n.internal.domain.model.locale.LocaleRepository;
+import org.seedstack.jpa.JpaUnit;
+import org.seedstack.seed.transaction.Transactional;
 
 import javax.inject.Inject;
 import java.util.HashSet;
@@ -23,6 +25,8 @@ import java.util.Set;
 /**
  * Locale service implementation.
  */
+@JpaUnit("seed-i18n-domain")
+@Transactional
 public class ICULocaleService implements LocaleService {
 
     private static final String LOCALE_MUST_NOT_BE_NULL = "locale must not be null";
@@ -58,6 +62,16 @@ public class ICULocaleService implements LocaleService {
     }
 
     @Override
+    public Set<String> getSupportedLocales() {
+        Set<String> supportedLocales = new HashSet<String>();
+        java.util.Locale[] locales = java.util.Locale.getAvailableLocales();
+        for (java.util.Locale locale : locales) {
+            supportedLocales.add(localeFactory.createFromLocale(locale).getEntityId());
+        }
+        return supportedLocales;
+    }
+
+    @Override
     public String getDefaultLocale() {
         Locale defaultLocale = localeRepository.getDefaultLocale();
         if (defaultLocale != null) {
@@ -74,21 +88,26 @@ public class ICULocaleService implements LocaleService {
 
     @Override
     public void addLocale(String locale) {
-        if (locale == null || locale.equals("")) {
-            throw new IllegalArgumentException(LOCALE_MUST_NOT_BE_NULL);
-        }
+        checkIsNotEmpty(locale);
         if (localeRepository.load(locale) == null) {
             Locale newLocale = localeFactory.createFromCode(locale);
             localeRepository.persist(newLocale);
         }
     }
 
-    @Override
-    public void deleteLocale(String locale) {
+    private void checkIsNotEmpty(String locale) {
         if (locale == null || locale.equals("")) {
             throw new IllegalArgumentException(LOCALE_MUST_NOT_BE_NULL);
         }
-        localeRepository.delete(localeRepository.load(locale));
+    }
+
+    @Override
+    public void deleteLocale(String locale) {
+        checkIsNotEmpty(locale);
+        Locale localeToDelete = localeRepository.load(locale);
+        if (localeToDelete != null) {
+            localeRepository.delete(localeToDelete);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/seedstack/i18n/internal/infrastructure/service/ICULocaleService.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/infrastructure/service/ICULocaleService.java
@@ -68,12 +68,12 @@ public class ICULocaleService implements LocaleService {
     }
 
     @Override
-    public synchronized void changeDefaultLocaleTo(String locale) {
+    public void changeDefaultLocaleTo(String locale) {
         localeRepository.changeDefaultLocaleTo(locale);
     }
 
     @Override
-    public synchronized void addLocale(String locale) {
+    public void addLocale(String locale) {
         if (locale == null || locale.equals("")) {
             throw new IllegalArgumentException(LOCALE_MUST_NOT_BE_NULL);
         }

--- a/core/src/main/java/org/seedstack/i18n/internal/infrastructure/service/ICULocalizationService.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/infrastructure/service/ICULocalizationService.java
@@ -22,6 +22,8 @@ import org.seedstack.i18n.internal.domain.model.key.Translation;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.seedstack.i18n.internal.domain.model.locale.Locale;
+import org.seedstack.jpa.JpaUnit;
+import org.seedstack.seed.transaction.Transactional;
 
 import javax.inject.Inject;
 import java.text.ParseException;
@@ -32,6 +34,8 @@ import java.util.List;
 /**
  * Localization service implementation based on ICU.
  */
+@JpaUnit("seed-i18n-domain")
+@Transactional
 public class ICULocalizationService implements LocalizationService {
 
     private final LocaleService localeService;

--- a/core/src/main/java/org/seedstack/i18n/internal/infrastructure/service/TranslationServiceImpl.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/infrastructure/service/TranslationServiceImpl.java
@@ -13,7 +13,9 @@ import org.seedstack.i18n.internal.TranslationService;
 import org.seedstack.i18n.internal.domain.model.key.Key;
 import org.seedstack.i18n.internal.domain.model.key.KeyRepository;
 import org.seedstack.i18n.internal.domain.model.key.Translation;
+import org.seedstack.jpa.JpaUnit;
 import org.seedstack.seed.Configuration;
+import org.seedstack.seed.transaction.Transactional;
 
 import javax.inject.Inject;
 import java.util.HashMap;
@@ -22,6 +24,8 @@ import java.util.Map;
 /**
  * @author pierre.thirouin@ext.mpsa.com
  */
+@JpaUnit("seed-i18n-domain")
+@Transactional
 public class TranslationServiceImpl implements TranslationService {
 
     public static final String IS_EMPTY_ERROR_MESSAGE = "The %s can't be null or empty";

--- a/core/src/test/java/org/seedstack/i18n/internal/domain/model/locale/LocaleCodeSpecificationTest.java
+++ b/core/src/test/java/org/seedstack/i18n/internal/domain/model/locale/LocaleCodeSpecificationTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.internal.domain.model.locale;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.seedstack.i18n.internal.domain.model.locale.Locale.formatLocaleCode;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class LocaleCodeSpecificationTest {
+
+    private final LocaleCodeSpecification underTest = new LocaleCodeSpecification();
+
+    @Test
+    public void testSatisfyByWithValidCodes() {
+        assertThat(underTest.isSatisfiedBy("fr")).isTrue();
+        assertThat(underTest.isSatisfiedBy("fr-BE")).isTrue();
+        assertThat(underTest.isSatisfiedBy(formatLocaleCode("ja_JP_JP_#u-ca-japanese"))).isTrue();
+    }
+
+    @Test
+    public void testSatisfyByWithInvalidCodes() {
+        assertThat(underTest.isSatisfiedBy("")).isFalse();
+        assertThat(underTest.isSatisfiedBy(null)).isFalse();
+        assertThat(underTest.isSatisfiedBy("fr_BE")).isFalse();
+        assertThat(underTest.isSatisfiedBy("fr BE")).isFalse();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAssertWit() {
+        LocaleCodeSpecification.assertCode("fr_BE");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAssert() {
+        LocaleCodeSpecification.assertCode(null);
+    }
+}

--- a/core/src/test/java/org/seedstack/i18n/internal/domain/model/locale/LocaleFactoryTest.java
+++ b/core/src/test/java/org/seedstack/i18n/internal/domain/model/locale/LocaleFactoryTest.java
@@ -48,8 +48,23 @@ public class LocaleFactoryTest {
         Locale frLocale = localeFactory.createFromCode("fr");
         assertLocale(frLocale, "fr", "français", "French");
 
-        Locale locale = localeFactory.createFromCode("fr-BE");
-        assertLocale(locale, "fr-BE", "français (Belgique)", "French (Belgium)");
+        Locale frBeLocale = localeFactory.createFromCode("fr-BE");
+        assertLocale(frBeLocale, "fr-BE", "français (Belgique)", "French (Belgium)");
+    }
+
+    @Test
+    public void testCreateFromLocale() {
+        java.util.Locale japLocale = new java.util.Locale("ja", "JP", "JP");
+        Locale locale = localeFactory.createFromLocale(japLocale);
+        Assertions.assertThat(locale.getEntityId()).isEqualTo("ja-JP-JP-#u-ca-japanese");
+        Assertions.assertThat(locale.getLanguage()).isEqualTo("日本語 (日本,JP)");
+        Assertions.assertThat(locale.getEnglishLanguage()).isEqualTo("Japanese (Japan,JP)");
+    }
+
+    @Test
+    public void testCreateNonExistentLocale() {
+        Locale nonexistentLocale = localeFactory.createFromCode("fr-CN");
+        assertLocale(nonexistentLocale, "fr-CN", "français (Chine)", "French (China)");
     }
 
     private void assertLocale(Locale locale, String code, String language, String englishLanguage) {

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -83,6 +83,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>1.20</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
             <version>${jsonassert.version}</version>

--- a/rest/src/it/java/org/seedstack/i18n/rest/MessageResourcesIT.java
+++ b/rest/src/it/java/org/seedstack/i18n/rest/MessageResourcesIT.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.rest;
+
+import com.jayway.restassured.response.Response;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.json.JSONException;
+import org.junit.Test;
+import org.seedstack.seed.it.AbstractSeedWebIT;
+
+import java.net.URL;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.junit.Assert.fail;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class MessageResourcesIT extends AbstractSeedWebIT {
+
+    private static final String BASE_URL = "seed-i18n";
+
+    @ArquillianResource
+    private URL baseURL;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class).setWebXML("WEB-INF/web.xml");
+    }
+
+    @RunAsClient
+    @Test
+    public void getTranslations() throws JSONException {
+        Response response = httpGet("/messages/en");
+        assertResponseHasStatusCode(response, 200);
+    }
+
+    private Response httpGet(String path) {
+        return given().auth().basic("admin", "password").header("Accept", "application/json")
+                .header("Content-Type", "application/json").get(baseURL.toString() + BASE_URL + path);
+    }
+
+    private void assertResponseHasStatusCode(Response response, int statusCode) {
+        if (response.statusCode() != statusCode) {
+            fail("Status code " + response.statusCode() + " [" + response.prettyPrint() + "]");
+        }
+    }
+}

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/I18nPermissions.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/I18nPermissions.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.rest.internal;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class I18nPermissions {
+
+    public static final String LOCALE_READ = "seed:i18n:locale:read";
+    public static final String LOCALE_WRITE = "seed:i18n:locale:write";
+    public static final String LOCALE_DELETE = "seed:i18n:locale:delete";
+}

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/jpa/LocaleJpaFinder.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/jpa/LocaleJpaFinder.java
@@ -13,13 +13,11 @@ import org.seedstack.i18n.internal.domain.model.locale.LocaleRepository;
 import org.seedstack.i18n.rest.internal.locale.LocaleAssembler;
 import org.seedstack.i18n.rest.internal.locale.LocaleFinder;
 import org.seedstack.i18n.rest.internal.locale.LocaleRepresentation;
-import org.seedstack.seed.Configuration;
 import org.seedstack.jpa.JpaUnit;
 import org.seedstack.seed.transaction.Transactional;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -35,15 +33,6 @@ public class LocaleJpaFinder implements LocaleFinder {
 
     @Inject
     private LocaleAssembler assembler;
-
-    @Configuration(value = "org.seedstack.i18n.additional-locales.codes", mandatory = false)
-    private String[] additionalLocaleCodes;
-
-    @Configuration(value = "org.seedstack.i18n.additional-locales.names", mandatory = false)
-    private String[] additionalLocaleNativeNames;
-
-    @Configuration(value = "org.seedstack.i18n.additional-locales.english-names", mandatory = false)
-    private String[] additionalLocaleEnglishNames;
 
     @Override
     public LocaleRepresentation findDefaultLocale() {
@@ -72,107 +61,5 @@ public class LocaleJpaFinder implements LocaleFinder {
             return assembler.assembleDtoFromAggregate(locale);
         }
         return null;
-    }
-
-    @Override
-    public List<LocaleRepresentation> findLocalesFullVersion() {
-        List<LocaleRepresentation> localeRepresentations = new ArrayList<LocaleRepresentation>();
-        ULocale[] locales = ULocale.getAvailableLocales();
-
-        for (ULocale locale : locales) {
-            localeRepresentations.add(assembleLocaleRepresentationFromLocale(locale));
-        }
-
-        localeRepresentations.addAll(buildAdditionalLocaleRepresentations());
-
-        Collections.sort(localeRepresentations);
-
-        return localeRepresentations;
-    }
-
-    @Override
-    public List<LocaleRepresentation> findLocales() {
-        List<LocaleRepresentation> localeRepresentations = new ArrayList<LocaleRepresentation>();
-        java.util.Locale[] locales = java.util.Locale.getAvailableLocales();
-
-        for (java.util.Locale locale : locales) {
-            localeRepresentations.add(assembleLocaleRepresentationFromLocale(locale));
-        }
-
-        localeRepresentations.addAll(buildAdditionalLocaleRepresentations());
-
-        Collections.sort(localeRepresentations);
-
-        return localeRepresentations;
-    }
-
-    @Override
-    public LocaleRepresentation findLocale(String localeCode) {
-        ULocale[] locales = ULocale.getAvailableLocales();
-        for (ULocale locale : locales) {
-            if (locale.toString().equals(localeCode)) {
-                return assembleLocaleRepresentationFromLocale(locale);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Assemble a locale from an ULocale (from ICU library).
-     *
-     * @param locale ULocale
-     * @return locale
-     */
-    LocaleRepresentation assembleLocaleRepresentationFromLocale(ULocale locale) {
-        LocaleRepresentation representation = new LocaleRepresentation();
-        representation.setCode(locale.getBaseName());
-        representation.setLanguage(locale.getDisplayNameWithDialect(locale));
-        representation.setEnglishLanguage(locale.getDisplayNameWithDialect(ULocale.ENGLISH));
-        return representation;
-    }
-
-    /**
-     * Assemble a locale from an java.util.Locale.
-     *
-     * @param locale locale
-     * @return locale representation
-     */
-    LocaleRepresentation assembleLocaleRepresentationFromLocale(java.util.Locale locale) {
-        LocaleRepresentation representation = new LocaleRepresentation();
-        representation.setCode(Locale.formatLocaleCode(locale.toString()));
-        representation.setLanguage(locale.getDisplayName(locale));
-        representation.setEnglishLanguage(locale.getDisplayName(java.util.Locale.ENGLISH));
-        return representation;
-    }
-
-    private List<LocaleRepresentation> buildAdditionalLocaleRepresentations() {
-        List<LocaleRepresentation> localeRepresentations = new ArrayList<LocaleRepresentation>();
-
-        if (additionalLocaleCodes != null) {
-            for (int i = 0; i < additionalLocaleCodes.length; i++) {
-                LocaleRepresentation additionalLocaleRepresentation = new LocaleRepresentation();
-                additionalLocaleRepresentation.setCode(additionalLocaleCodes[i]);
-
-                if (additionalLocaleEnglishNames != null) {
-                    if (i < additionalLocaleEnglishNames.length) {
-                        additionalLocaleRepresentation.setEnglishLanguage(additionalLocaleEnglishNames[i]);
-                    } else {
-                        additionalLocaleRepresentation.setEnglishLanguage(additionalLocaleCodes[i]);
-                    }
-                }
-
-                if (additionalLocaleNativeNames != null) {
-                    if (i < additionalLocaleNativeNames.length) {
-                        additionalLocaleRepresentation.setLanguage(additionalLocaleNativeNames[i]);
-                    } else {
-                        additionalLocaleRepresentation.setLanguage(additionalLocaleCodes[i]);
-                    }
-                }
-
-                localeRepresentations.add(additionalLocaleRepresentation);
-            }
-        }
-
-        return localeRepresentations;
     }
 }

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/locale/AvailableLocalesResource.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/locale/AvailableLocalesResource.java
@@ -11,6 +11,7 @@ import org.seedstack.i18n.LocaleService;
 import org.seedstack.i18n.internal.domain.model.locale.Locale;
 import org.seedstack.i18n.internal.domain.model.locale.LocaleFactory;
 import org.seedstack.i18n.internal.domain.model.locale.LocaleRepository;
+import org.seedstack.i18n.rest.internal.I18nPermissions;
 import org.seedstack.i18n.rest.internal.shared.SeedWebCheckUtils;
 import org.apache.commons.lang.StringUtils;
 import org.seedstack.jpa.JpaUnit;
@@ -59,7 +60,7 @@ public class AvailableLocalesResource {
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @RequiresPermissions("seed:i18n:locale:read")
+    @RequiresPermissions(I18nPermissions.LOCALE_READ)
     public Response getAvailableLocales() {
         List<LocaleRepresentation> availableLocales = localeFinder.findAvailableLocales();
         if (!availableLocales.isEmpty()) {
@@ -77,7 +78,7 @@ public class AvailableLocalesResource {
     @GET
     @Path("/{localeId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @RequiresPermissions("seed:i18n:locale:read")
+    @RequiresPermissions(I18nPermissions.LOCALE_READ)
     public Response getAvailableLocale(@PathParam("localeId") String localeId) {
         SeedWebCheckUtils.checkIfNotBlank(localeId, LOCALE_SHOULD_NOT_BE_BLANK);
         LocaleRepresentation availableLocale = localeFinder.findAvailableLocale(localeId);
@@ -98,7 +99,7 @@ public class AvailableLocalesResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @RequiresPermissions("seed:i18n:locale:write")
+    @RequiresPermissions(I18nPermissions.LOCALE_WRITE)
     public Response addAvailableLocale(LocaleRepresentation representation, @Context UriInfo uriInfo) throws URISyntaxException {
         SeedWebCheckUtils.checkIfNotNull(representation, LOCALE_SHOULD_NOT_BE_BLANK);
         Locale locale = localeRepository.load(representation.getCode());
@@ -125,7 +126,7 @@ public class AvailableLocalesResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @RequiresPermissions("seed:i18n:locale:write")
+    @RequiresPermissions(I18nPermissions.LOCALE_WRITE)
     public Response replaceAvailableLocales(List<LocaleRepresentation> representations, @Context UriInfo uriInfo) throws URISyntaxException {
         // Delete the old list of available locales
         localeRepository.clear();
@@ -160,7 +161,7 @@ public class AvailableLocalesResource {
      */
     @DELETE
     @Path("/{locale}")
-    @RequiresPermissions("seed:i18n:locale:delete")
+    @RequiresPermissions(I18nPermissions.LOCALE_DELETE)
     public Response deleteAvailableLocale(@PathParam("locale") String locale) {
         SeedWebCheckUtils.checkIfNotBlank(locale, LOCALE_SHOULD_NOT_BE_BLANK);
         if (locale != null) {
@@ -178,7 +179,7 @@ public class AvailableLocalesResource {
      * @return status code 204 (no content)
      */
     @DELETE
-    @RequiresPermissions("seed:i18n:locale:delete")
+    @RequiresPermissions(I18nPermissions.LOCALE_DELETE)
     public Response deleteAllAvailableLocales() {
         List<Locale> locales = localeRepository.loadAll();
         for (Locale locale : locales) {

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/locale/LocaleFinder.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/locale/LocaleFinder.java
@@ -35,27 +35,10 @@ public interface LocaleFinder {
 
     /**
      * Returns the locale corresponding to the specified locale code.
+     *
      * @param localeCode the specified locale code
      * @return a representation of the requested locale
      */
     LocaleRepresentation findAvailableLocale(String localeCode);
 
-    /**
-     * Returns all the available locales in the ICU library
-     * @return a list of locale representations
-     */
-    List<LocaleRepresentation> findLocalesFullVersion();
-
-    /**
-     * Returns all the available locales in the JVM.
-     * @return a list of locale representations
-     */
-    List<LocaleRepresentation> findLocales();
-
-    /**
-     * Returns the locale corresponding to the locale code
-     * @param localeCode the specified locale code
-     * @return a locale representation
-     */
-    LocaleRepresentation findLocale(String localeCode);
 }

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/locale/SupportedLocaleFinder.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/locale/SupportedLocaleFinder.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.rest.internal.locale;
+
+import org.seedstack.business.finder.Finder;
+
+import java.util.List;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@Finder
+public interface SupportedLocaleFinder {
+
+    List<LocaleRepresentation> findSupportedLocales();
+
+    LocaleRepresentation findSupportedLocale(String localeCode);
+}

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/locale/SupportedLocaleFinderImpl.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/locale/SupportedLocaleFinderImpl.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.rest.internal.locale;
+
+import org.seedstack.i18n.internal.domain.model.locale.Locale;
+import org.seedstack.i18n.internal.domain.model.locale.LocaleFactory;
+import org.seedstack.seed.Configuration;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Finds the locales available on the platform.
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+class SupportedLocaleFinderImpl implements SupportedLocaleFinder {
+
+    private final LocaleFactory localeFactory;
+    private final LocaleAssembler localeAssembler;
+
+    @Configuration(value = "org.seedstack.i18n.additional-locales", mandatory = false)
+    private String[] additionalLocaleCodes;
+
+    @Inject
+    public SupportedLocaleFinderImpl(LocaleFactory localeFactory, LocaleAssembler localeAssembler) {
+        this.localeFactory = localeFactory;
+        this.localeAssembler = localeAssembler;
+    }
+
+    @Override
+    public List<LocaleRepresentation> findSupportedLocales() {
+        List<LocaleRepresentation> localeRepresentations = new ArrayList<LocaleRepresentation>();
+        for (java.util.Locale jLocale : java.util.Locale.getAvailableLocales()) {
+            if (!jLocale.toString().equals("")) {
+                localeRepresentations.add(convertToLocaleRepresentation(jLocale));
+            }
+        }
+        localeRepresentations.addAll(findAdditionalLocale());
+        Collections.sort(localeRepresentations);
+        return localeRepresentations;
+    }
+
+    private LocaleRepresentation convertToLocaleRepresentation(java.util.Locale jLocale) {
+        Locale locale = localeFactory.createFromLocale(jLocale);
+        return localeAssembler.assembleDtoFromAggregate(locale);
+    }
+
+    private List<LocaleRepresentation> findAdditionalLocale() {
+        List<LocaleRepresentation> localeRepresentations = new ArrayList<LocaleRepresentation>();
+        if (additionalLocaleCodes != null) {
+            for (String additionalLocaleCode : additionalLocaleCodes) {
+                Locale locale = localeFactory.createFromCode(additionalLocaleCode);
+                localeRepresentations.add(localeAssembler.assembleDtoFromAggregate(locale));
+            }
+        }
+        return localeRepresentations;
+    }
+
+    @Override
+    public LocaleRepresentation findSupportedLocale(String localeCode) {
+        for (LocaleRepresentation localeRepresentation : findSupportedLocales()) {
+            if (localeRepresentation.getCode().equals(localeCode)) {
+                return localeRepresentation;
+            }
+        }
+        return null;
+    }
+}

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/locale/SupportedLocalesResource.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/locale/SupportedLocalesResource.java
@@ -7,10 +7,9 @@
  */
 package org.seedstack.i18n.rest.internal.locale;
 
+import org.seedstack.i18n.rest.internal.I18nPermissions;
 import org.seedstack.i18n.rest.internal.shared.SeedWebCheckUtils;
-import org.seedstack.jpa.JpaUnit;
 import org.seedstack.seed.security.RequiresPermissions;
-import org.seedstack.seed.transaction.Transactional;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -25,26 +24,27 @@ import java.util.List;
  * This REST resource provide access to applications locales.
  *
  * @author pierre.thirouin@ext.mpsa.com
- *         Date: 26/11/13
  */
-@JpaUnit("seed-i18n-domain")
-@Transactional
 @Path("/seed-i18n/locales")
-public class LocalesResource {
+public class SupportedLocalesResource {
+
+    private final SupportedLocaleFinder supportedLocaleFinder;
 
     @Inject
-    private LocaleFinder localeFinder;
+    public SupportedLocalesResource(SupportedLocaleFinder supportedLocaleFinder) {
+        this.supportedLocaleFinder = supportedLocaleFinder;
+    }
 
     /**
-     * Returns all possible locale.
+     * Returns all the locales supported.
      *
-     * @return status code 200 with list of locale representation
+     * @return status code 200 with the locales or 204 if no locale are supported
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @RequiresPermissions("seed:i18n:locale:read")
-    public Response getLocales() {
-        List<LocaleRepresentation> locales = localeFinder.findLocales();
+    @RequiresPermissions(I18nPermissions.LOCALE_READ)
+    public Response getSupportedLocales() {
+        List<LocaleRepresentation> locales = supportedLocaleFinder.findSupportedLocales();
         if (!locales.isEmpty()) {
 			return Response.ok(locales).build();
 		}
@@ -54,16 +54,16 @@ public class LocalesResource {
     /**
      * Returns the requested locale.
      *
-     * @param localeId locale code
-     * @return status code 200 with the locale representation or 404 if not found
+     * @param localeCode locale code
+     * @return status code 200 with the locale or 404 if not found
      */
     @GET
-    @Path("/{localeId}")
+    @Path("/{localeCode}")
     @Produces(MediaType.APPLICATION_JSON)
-    @RequiresPermissions("seed:i18n:locale:read")
-    public Response getLocale(@PathParam("localeId") String localeId) {
-        SeedWebCheckUtils.checkIfNotNull(localeId, "The locale should not be null");
-        LocaleRepresentation locale = localeFinder.findLocale(localeId);
+    @RequiresPermissions(I18nPermissions.LOCALE_READ)
+    public Response getSupportedLocale(@PathParam("localeCode") String localeCode) {
+        SeedWebCheckUtils.checkIfNotNull(localeCode, "The locale should not be null");
+        LocaleRepresentation locale = supportedLocaleFinder.findSupportedLocale(localeCode);
         if (locale != null) {
 			return Response.ok(locale).build();
 		}

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/messages/MessageResource.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/messages/MessageResource.java
@@ -8,9 +8,6 @@
 package org.seedstack.i18n.rest.internal.messages;
 
 import com.google.common.cache.LoadingCache;
-import org.seedstack.i18n.rest.internal.shared.SeedWebCheckUtils;
-import org.seedstack.jpa.JpaUnit;
-import org.seedstack.seed.transaction.Transactional;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -25,10 +22,7 @@ import java.util.Map;
  * This REST resource provide method to access all the application message.
  *
  * @author pierre.thirouin@ext.mpsa.com
- *         Date: 17/04/2014
  */
-@JpaUnit("seed-i18n-domain")
-@Transactional
 @Path("/seed-i18n/messages")
 public class MessageResource {
 
@@ -45,7 +39,6 @@ public class MessageResource {
     @Path("/{locale}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getTranslations(@PathParam("locale") String locale) {
-        SeedWebCheckUtils.checkIfNotBlank(locale, "The locale should not be blank");
         Map<String, String> messages = loadingCache.getUnchecked(locale);
         if (messages != null && !messages.isEmpty()) {
 			return Response.ok(messages).build();

--- a/rest/src/test/java/org/seedstack/i18n/rest/internal/locale/SupportedLocaleFinderImplTest.java
+++ b/rest/src/test/java/org/seedstack/i18n/rest/internal/locale/SupportedLocaleFinderImplTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.rest.internal.locale;
+
+import mockit.*;
+import mockit.integration.junit4.JMockit;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.seedstack.i18n.internal.domain.model.locale.Locale;
+import org.seedstack.i18n.internal.domain.model.locale.LocaleFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@RunWith(JMockit.class)
+public class SupportedLocaleFinderImplTest {
+
+    public static final String EN = "en";
+    public static final String FR = "fr";
+    private final java.util.Locale enJLocale = new java.util.Locale(EN);
+    private final java.util.Locale frJLocale = new java.util.Locale(FR);
+
+    @Tested
+    private SupportedLocaleFinderImpl underTest;
+    @Injectable
+    private LocaleFactory localeFactory;
+    @Injectable
+    private LocaleAssembler localeAssembler;
+    @Mocked
+    private Locale enLocale;
+    @Mocked
+    private Locale frLocale;
+    private LocaleRepresentation frLocaleRepresentation;
+    private LocaleRepresentation enLocaleRepresentation;
+
+    @Before
+    public void setUp() throws Exception {
+        enLocaleRepresentation = new LocaleRepresentation();
+        enLocaleRepresentation.setCode(EN);
+        enLocaleRepresentation.setLanguage("English");
+        enLocaleRepresentation.setEnglishLanguage("English");
+
+        frLocaleRepresentation = new LocaleRepresentation();
+        frLocaleRepresentation.setCode(FR);
+        frLocaleRepresentation.setLanguage("français");
+        frLocaleRepresentation.setEnglishLanguage("French");
+    }
+
+    @Test
+    public void testFindSupportedLocalesDontReturnNull() {
+        mockAvailableLocales();
+        List<LocaleRepresentation> supportedLocales = underTest.findSupportedLocales();
+        Assertions.assertThat(supportedLocales).isNotNull();
+        Assertions.assertThat(supportedLocales).isEmpty();
+    }
+
+    private void mockAvailableLocales(final String... localeCodes) {
+        new MockUp<java.util.Locale>() {
+
+            @Mock
+            java.util.Locale[] getAvailableLocales() {
+                List<java.util.Locale> locales = new ArrayList<java.util.Locale>();
+                for (String locale : localeCodes) {
+                    locales.add(new java.util.Locale(locale));
+                }
+                return locales.toArray(new java.util.Locale[]{});
+            }
+        };
+    }
+
+    @Test
+    public void testFindSupportedLocales() {
+        mockAvailableLocales(EN, FR);
+        mockAssemblerForEN();
+        mockAssemblerForFR();
+
+        List<LocaleRepresentation> supportedLocales = underTest.findSupportedLocales();
+        Assertions.assertThat(supportedLocales).hasSize(2);
+        Assertions.assertThat(supportedLocales.get(0).getCode()).isEqualTo(EN);
+        Assertions.assertThat(supportedLocales.get(1).getCode()).isEqualTo(FR);
+    }
+
+    public void mockAssemblerForEN() {
+        mockAssembler(enJLocale, enLocale, enLocaleRepresentation);
+    }
+
+    public void mockAssemblerForFR() {
+        mockAssembler(frJLocale, frLocale, frLocaleRepresentation);
+    }
+
+    public void mockAssembler(final java.util.Locale jLocale, final Locale locale, final LocaleRepresentation localeRepresentation) {
+        new Expectations() {
+            {
+                localeFactory.createFromLocale(jLocale);
+                result = locale;
+
+                localeAssembler.assembleDtoFromAggregate(locale);
+                result = localeRepresentation;
+            }
+        };
+    }
+
+    @Test
+    public void testFindSupportedLocale() {
+        mockAvailableLocales(EN, FR);
+        mockAssemblerForEN();
+        mockAssemblerForFR();
+        LocaleRepresentation locale = underTest.findSupportedLocale(FR);
+        Assertions.assertThat(locale.getCode()).isEqualTo(FR);
+        Assertions.assertThat(locale.getEnglishLanguage()).isEqualTo("French");
+    }
+
+    @Test
+    public void testFindSupportedLocaleReturnNull() {
+        mockAvailableLocales();
+        Assertions.assertThat(underTest.findSupportedLocale(FR)).isNull();
+    }
+
+    @Test
+    public void testAdditionalLocalesCodes() {
+        mockAvailableLocales(EN);
+        mockAssemblerForEN();
+        mockAssemblerForAdditionalLocale("fr", frLocale, frLocaleRepresentation);
+
+        Deencapsulation.setField(underTest, "additionalLocaleCodes", new String[]{"fr"});
+
+        LocaleRepresentation supportedLocale = underTest.findSupportedLocale("fr");
+        Assertions.assertThat(supportedLocale).isNotNull();
+        Assertions.assertThat(supportedLocale.getCode()).isEqualTo("fr");
+
+        Assertions.assertThat(underTest.findSupportedLocales()).hasSize(2);
+    }
+
+    public void mockAssemblerForAdditionalLocale(final String localeCode, final Locale locale, final LocaleRepresentation localeRepresentation) {
+        new Expectations() {
+            {
+                localeFactory.createFromCode(localeCode);
+                result = locale;
+
+                localeAssembler.assembleDtoFromAggregate(locale);
+                result = localeRepresentation;
+            }
+        };
+    }
+}

--- a/specs/src/main/java/org/seedstack/i18n/LocaleService.java
+++ b/specs/src/main/java/org/seedstack/i18n/LocaleService.java
@@ -40,7 +40,7 @@ public interface LocaleService {
     /**
      * Returns the application's default locale.
      *
-     * @return The locale defined as default in the repository
+     * @return The default locale or null if there is no default locale
      */
     String getDefaultLocale();
 

--- a/specs/src/main/java/org/seedstack/i18n/LocaleService.java
+++ b/specs/src/main/java/org/seedstack/i18n/LocaleService.java
@@ -33,9 +33,16 @@ public interface LocaleService {
     /**
      * Returns all the available locales for the application.
      *
-     * @return a set with all the locales or an empty set if no locale is present.
+     * @return a set with all the locales.
      */
     Set<String> getAvailableLocales();
+
+    /**
+     * Returns all the locales supported by the platform.
+     *
+     * @return a set with the supported locales.
+     */
+    Set<String> getSupportedLocales();
 
     /**
      * Returns the application's default locale.
@@ -48,7 +55,7 @@ public interface LocaleService {
      * Returns the closest locale from the given locale which is supported by the application.
      *
      * @param locale The locale to match.
-     * @return The supported locale.
+     * @return The supported locale or null if there is no close locale
      */
     String getClosestLocale(String locale);
 
@@ -67,7 +74,7 @@ public interface LocaleService {
      * </p>
      *
      * @param locale the locale to add.
-     * @throws IllegalArgumentException if the locale is null.
+     * @throws IllegalArgumentException if the locale argument is null.
      */
     void addLocale(String locale);
 
@@ -78,7 +85,7 @@ public interface LocaleService {
      * </p>
      *
      * @param locale the locale to delete.
-     * @throws IllegalArgumentException if the locale is null.
+     * @throws IllegalArgumentException if the locale argument is null.
      */
     void deleteLocale(String locale);
 }


### PR DESCRIPTION
Extract the supported locale retrieving in a `SupportedLocaleFinder`. The supported locale are now validated using the domain model which improves the global robustness.

The additional language feature have been simplified in the process. The configuration don't need the language and English language any more. You can now configure it as follows:

    org.seedstack.i18n.additional-locales=fr,fr-BE,en,en-CA

