### PR TITLE
Fix allowMissingTranslation

### DIFF
--- a/core/src/main/java/org/seedstack/i18n/internal/infrastructure/service/TranslationServiceImpl.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/infrastructure/service/TranslationServiceImpl.java
@@ -33,7 +33,14 @@ public class TranslationServiceImpl implements TranslationService {
     private final LocalizationService localizationService;
     private final LocaleService localeService;
 
-    @Configuration(value = "org.seedstack.i18n.allow-missing-translation", defaultValue = "false")
+    /**
+     * The allowMissingTranslation field is true by default.
+     * <ul>
+     * <li>When true the missing translation won't appear in the key/translation map.</li>
+     * <li>When false they will appear with the translation [key.name]</li>
+     * </ul>
+     */
+    @Configuration(value = "org.seedstack.i18n.allow-missing-translation", defaultValue = "true")
     private boolean allowMissingTranslation;
 
     /**
@@ -54,7 +61,7 @@ public class TranslationServiceImpl implements TranslationService {
     public Map<String, String> getTranslationsForLocale(String locale) {
         Map<String, String> translations = new HashMap<String, String>();
         for (Key key : keyRepository.loadAll()) {
-            if (allowMissingTranslation || key.isTranslated(locale)) {
+            if (key.isTranslated(locale) || !allowMissingTranslation) {
                 String translation = localizationService.localize(locale, key.getEntityId());
                 translations.put(key.getEntityId(), translation);
             }

--- a/core/src/test/java/org/seedstack/i18n/internal/infrastructure/service/TranslationServiceImplTest.java
+++ b/core/src/test/java/org/seedstack/i18n/internal/infrastructure/service/TranslationServiceImplTest.java
@@ -87,7 +87,7 @@ public class TranslationServiceImplTest {
     }
 
     @Test
-    public void testLocalizationWithMissingTranslations() {
+    public void testLocalizationAllowMissingTranslations() {
         new Expectations() {
             {
                 Key key1 = new Key(KEY1);
@@ -101,6 +101,7 @@ public class TranslationServiceImplTest {
                 result = FR_BE_TRANSLATION;
             }
         };
+        Deencapsulation.setField(underTest, "allowMissingTranslation", true);
 
         Map<String, String> translationsForLocale = underTest.getTranslationsForLocale(FR_BE);
 
@@ -109,7 +110,7 @@ public class TranslationServiceImplTest {
     }
 
     @Test
-    public void testLocalizationWithAllowMissingTranslations() {
+    public void testLocalizationDoNotAllowMissingTranslations() {
         new Expectations() {
             {
                 Key key1 = new Key(KEY1);
@@ -123,16 +124,16 @@ public class TranslationServiceImplTest {
                 result = FR_BE_TRANSLATION;
 
                 localizationService.localize(FR_BE, KEY2);
-                result = FR_BE_TRANSLATION;
+                result = "[key2]";
             }
         };
-        Deencapsulation.setField(underTest, "allowMissingTranslation", true);
+        Deencapsulation.setField(underTest, "allowMissingTranslation", false);
 
         Map<String, String> translationsForLocale = underTest.getTranslationsForLocale(FR_BE);
 
         Assertions.assertThat(translationsForLocale).hasSize(2);
         Assertions.assertThat(translationsForLocale).containsEntry(KEY1, FR_BE_TRANSLATION);
-        Assertions.assertThat(translationsForLocale).containsEntry(KEY2, FR_BE_TRANSLATION);
+        Assertions.assertThat(translationsForLocale).containsEntry(KEY2, "[key2]");
     }
 
     @Test


### PR DESCRIPTION
The property `org.seedstack.i18n.allow-missing-translation` is now true by default.

* When **true** the missing translation won't appear in the key/translation map.
* When **false** they will appear with the translation `[key.name]`