### PR TITLE
Fix import should add null translations

### DIFF
--- a/core/src/it/java/org/seedstack/i18n/ExportDataIT.java
+++ b/core/src/it/java/org/seedstack/i18n/ExportDataIT.java
@@ -16,10 +16,8 @@ import org.seedstack.i18n.internal.domain.model.key.KeyFactory;
 import org.seedstack.i18n.internal.domain.model.key.KeyRepository;
 import org.seedstack.jpa.JpaUnit;
 import org.seedstack.seed.DataManager;
-import org.seedstack.seed.Logging;
 import org.seedstack.seed.it.SeedITRunner;
 import org.seedstack.seed.transaction.Transactional;
-import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import java.io.ByteArrayInputStream;
@@ -46,9 +44,6 @@ public class ExportDataIT {
     @Inject
     private KeyRepository keyRepository;
 
-    @Logging
-    private Logger logger;
-
     @Before
     public void setUp() {
         Key key1 = keyFactory.createKey(KEY_NAME);
@@ -62,12 +57,10 @@ public class ExportDataIT {
         // Export
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         dataManager.exportData(outputStream, "seed-i18n");
-        logger.info(new String(outputStream.toByteArray()));
 
         // Remove data
         keyRepository.delete(keyRepository.load(KEY_NAME));
-        Key deletedKey = keyRepository.load(KEY_NAME);
-        Assertions.assertThat(deletedKey).isNull();
+
         ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
         dataManager.importData(inputStream, null, null, true);
 

--- a/core/src/it/java/org/seedstack/i18n/LocaleServiceIT.java
+++ b/core/src/it/java/org/seedstack/i18n/LocaleServiceIT.java
@@ -13,10 +13,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.seedstack.jpa.JpaUnit;
-import org.seedstack.seed.Logging;
 import org.seedstack.seed.it.SeedITRunner;
 import org.seedstack.seed.transaction.Transactional;
-import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import java.util.Set;
@@ -32,15 +30,11 @@ public class LocaleServiceIT {
     @Inject
     public LocaleService localeService;
 
-    @Logging
-    private Logger logger;
-
     @Test
     public void manage_default_locale() {
         String locale = "zh";
         // Add a new locale
         localeService.addLocale(locale);
-        logger.info("ADD {} LOCALE", locale);
 
         boolean isAvailable = localeService.isAvailable(locale);
         Assertions.assertThat(isAvailable).isEqualTo(true);
@@ -50,7 +44,6 @@ public class LocaleServiceIT {
 
         // Set the locale as default locale
         localeService.changeDefaultLocaleTo(locale);
-        logger.info("CHANGE DEFAULT LOCALE TO {}", locale);
 
         // Check if default locale has changed
         String defaultLocale = localeService.getDefaultLocale();
@@ -58,7 +51,6 @@ public class LocaleServiceIT {
 
         // Delete the locale
         localeService.deleteLocale(locale);
-        logger.info("DELETE DEFAULT LOCALE", locale);
 
         // Check that the locale has been deleted
         isAvailable = localeService.isAvailable(locale);
@@ -67,11 +59,10 @@ public class LocaleServiceIT {
         // Check if default locale has changed to default
         defaultLocale = localeService.getDefaultLocale();
         Assertions.assertThat(defaultLocale).isNull();
-        logger.info("DEFAULT LOCALE IS NOW {}", defaultLocale);
     }
 
     @Test
-    public void muliple_locales() {
+    public void multiple_locales() {
         localeService.addLocale("en");
         localeService.addLocale("en-US");
         localeService.addLocale("en-GB");

--- a/core/src/main/java/org/seedstack/i18n/internal/domain/model/key/Key.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/domain/model/key/Key.java
@@ -85,6 +85,9 @@ public class Key extends BaseAggregateRoot<String> implements Serializable {
      */
     public Translation addTranslation(String locale, String value, boolean isApproximate) {
         LocaleCodeSpecification.assertCode(locale);
+        if (value == null || value.trim().equals("")) {
+            throw new IllegalArgumentException("The translation can't be blank");
+        }
 
         // If exists, get the translation for the given locale
         Translation translation = this.translations.get(locale);

--- a/core/src/main/java/org/seedstack/i18n/internal/domain/model/key/KeyRepository.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/domain/model/key/KeyRepository.java
@@ -38,6 +38,7 @@ public interface KeyRepository extends GenericRepository<Key, String> {
      *
      * @param keys keys to persist
      */
+    @Deprecated
     void persistAll(List<Key> keys);
 
     /**

--- a/core/src/main/java/org/seedstack/i18n/internal/infrastructure/jpa/KeyJpaRepository.java
+++ b/core/src/main/java/org/seedstack/i18n/internal/infrastructure/jpa/KeyJpaRepository.java
@@ -47,6 +47,7 @@ class KeyJpaRepository extends BaseJpaRepository<Key, String> implements KeyRepo
 
     @Override
     public void deleteAll() {
+        // TODO this request is intended to be faster that delete(List<Key>) so don't use a loop !
         for (Key key : loadAll()) {
             entityManager.remove(key);
         }

--- a/core/src/test/java/org/seedstack/i18n/internal/domain/model/key/KeyTest.java
+++ b/core/src/test/java/org/seedstack/i18n/internal/domain/model/key/KeyTest.java
@@ -40,6 +40,21 @@ public class KeyTest {
         Assertions.assertThat(key.getComment()).isEqualTo("Indicates the number ninety");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testKeyAddTranslationWithInvalidLocale() {
+        new Key(KEY).addTranslation(INVALID_LOCALE, FR_TRANSLATION);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTranslationCantBeNull() {
+        new Key(KEY).addTranslation(FR, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLocaleCantBeNull() {
+        new Key(KEY).addTranslation(null, FR_TRANSLATION);
+    }
+
     @Test
     public void testKeyAddTranslation() {
         Key key = new Key(KEY);
@@ -63,11 +78,6 @@ public class KeyTest {
         Translation initialTranslation = key.addTranslation(FR, FR_TRANSLATION);
         Translation newTranslation = key.addTranslation(FR, FR_BE_TRANSLATION);
         Assertions.assertThat(initialTranslation).isEqualTo(newTranslation);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testKeyAddTranslationWithInvalidLocale() {
-        new Key(KEY).addTranslation(INVALID_LOCALE, FR_TRANSLATION);
     }
 
     @Test

--- a/rest/src/it/java/org/seedstack/i18n/internal/infrastructure/csv/CSVImportServiceIT.java
+++ b/rest/src/it/java/org/seedstack/i18n/internal/infrastructure/csv/CSVImportServiceIT.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.internal.infrastructure.csv;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.seedstack.i18n.internal.domain.model.key.Key;
+import org.seedstack.i18n.internal.domain.model.key.KeyRepository;
+import org.seedstack.i18n.rest.internal.io.ImportService;
+import org.seedstack.jpa.JpaUnit;
+import org.seedstack.seed.it.SeedITRunner;
+import org.seedstack.seed.transaction.Transactional;
+
+import javax.inject.Inject;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@JpaUnit("seed-i18n-domain")
+@Transactional
+@RunWith(SeedITRunner.class)
+public class CSVImportServiceIT {
+
+    @Inject
+    private ImportService csvImportService;
+    @Inject
+    private KeyRepository keyRepository;
+
+    private String keyName;
+
+    @Before
+    public void setUp() throws Exception {
+        keyName = UUID.randomUUID().toString();
+        System.out.printf(keyName);
+    }
+
+    @Test
+    public void testServiceIsInjectable() throws Exception {
+        assertThat(csvImportService).isNotNull();
+    }
+
+    @Test
+    public void testImportEmptyStream() throws Exception {
+        InputStream emptyInputStream = new ByteArrayInputStream("".getBytes());
+        int importedKeys = csvImportService.importKeysWithTranslations(emptyInputStream);
+        assertThat(importedKeys).isEqualTo(0);
+    }
+
+    private ByteArrayInputStream givenCsvWithKeys() {
+        String content = "key;en;fr\n" + keyName + ";bar;\n";
+        return new ByteArrayInputStream(content.getBytes());
+    }
+
+    @Test
+    public void testImportKeys() throws Exception {
+        InputStream emptyInputStream = givenCsvWithKeys();
+        int importedKeys = csvImportService.importKeysWithTranslations(emptyInputStream);
+        assertThat(importedKeys).isEqualTo(1);
+    }
+
+    @Test
+    public void testImportKeysHasBeenPersisted() throws Exception {
+        InputStream emptyInputStream = givenCsvWithKeys();
+
+        csvImportService.importKeysWithTranslations(emptyInputStream);
+
+        Key foo = keyRepository.load(keyName);
+        assertThat(foo).isNotNull();
+        assertThat(foo.getEntityId()).isEqualTo(keyName);
+        assertThat(foo.getTranslation("en").getValue()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testDoNotImportEmptyTranslation() throws Exception {
+        InputStream emptyInputStream = givenCsvWithKeys();
+
+        csvImportService.importKeysWithTranslations(emptyInputStream);
+
+        Key foo = keyRepository.load(keyName);
+        assertThat(foo.isTranslated("fr")).isFalse();
+    }
+
+    @Test
+    public void testReImportKeysWorks() throws Exception {
+        csvImportService.importKeysWithTranslations(givenCsvWithKeys());
+        csvImportService.importKeysWithTranslations(givenCsvWithKeys());
+    }
+}

--- a/rest/src/it/java/org/seedstack/i18n/internal/infrastructure/jpa/KeyJpaFinderIT.java
+++ b/rest/src/it/java/org/seedstack/i18n/internal/infrastructure/jpa/KeyJpaFinderIT.java
@@ -88,7 +88,6 @@ public class KeyJpaFinderIT {
 
         Key key = keyFactory.createKey(KEY_WITH_MISSING_TRANSLATION);
         key.addTranslation(FR, TRANSLATION_FR);
-        key.addTranslation(FR, "");
         keys.add(key);
 
         keyRepository.persistAll(keys);

--- a/rest/src/it/java/org/seedstack/i18n/internal/rest/DefaultLocaleResourceIT.java
+++ b/rest/src/it/java/org/seedstack/i18n/internal/rest/DefaultLocaleResourceIT.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest;
+package org.seedstack.i18n.internal.rest;
 
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.json.JSONArray;

--- a/rest/src/it/java/org/seedstack/i18n/internal/rest/KeyResourceIT.java
+++ b/rest/src/it/java/org/seedstack/i18n/internal/rest/KeyResourceIT.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest;
+package org.seedstack.i18n.internal.rest;
 
 import com.jayway.restassured.response.Response;
 import org.assertj.core.api.Assertions;

--- a/rest/src/it/java/org/seedstack/i18n/internal/rest/LocalesResourcesIT.java
+++ b/rest/src/it/java/org/seedstack/i18n/internal/rest/LocalesResourcesIT.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest;
+package org.seedstack.i18n.internal.rest;
 
 import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.container.test.api.RunAsClient;

--- a/rest/src/it/java/org/seedstack/i18n/internal/rest/MessageResourcesIT.java
+++ b/rest/src/it/java/org/seedstack/i18n/internal/rest/MessageResourcesIT.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest;
+package org.seedstack.i18n.internal.rest;
 
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.json.JSONException;

--- a/rest/src/it/java/org/seedstack/i18n/internal/rest/StatisticResourcesIT.java
+++ b/rest/src/it/java/org/seedstack/i18n/internal/rest/StatisticResourcesIT.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest;
+package org.seedstack.i18n.internal.rest;
 
 import com.jayway.restassured.response.Response;
 import org.assertj.core.api.Assertions;

--- a/rest/src/it/java/org/seedstack/i18n/internal/rest/TranslationsResourceIT.java
+++ b/rest/src/it/java/org/seedstack/i18n/internal/rest/TranslationsResourceIT.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest;
+package org.seedstack.i18n.internal.rest;
 
 import com.jayway.restassured.response.Response;
 import org.assertj.core.api.Assertions;

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CSVImportService.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CSVImportService.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
+
+import org.seedstack.business.assembler.FluentAssembler;
+import org.seedstack.i18n.internal.domain.model.key.Key;
+import org.seedstack.i18n.internal.domain.model.key.KeyRepository;
+import org.seedstack.i18n.rest.internal.io.I18nCSVRepresentation;
+import org.seedstack.i18n.rest.internal.io.ImportService;
+import org.seedstack.io.Parse;
+import org.seedstack.io.Parser;
+import org.seedstack.jpa.JpaUnit;
+import org.seedstack.seed.transaction.Transactional;
+
+import javax.inject.Inject;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class CSVImportService implements ImportService {
+
+    @Parse(I18nCSVTemplateLoader.I18N_CSV_TEMPLATE)
+    private Parser<I18nCSVRepresentation> parser;
+
+    private FluentAssembler fluentAssembler;
+    private KeyRepository keyRepository;
+
+    @Inject
+    public CSVImportService(FluentAssembler fluentAssembler, KeyRepository keyRepository) {
+        this.fluentAssembler = fluentAssembler;
+        this.keyRepository = keyRepository;
+    }
+
+    /**
+     * Non injected constructor used for testing.
+     *
+     * @param fluentAssembler the assembler DSL
+     * @param keyRepository   the key repository
+     * @param parser          the CSV parser
+     */
+    CSVImportService(FluentAssembler fluentAssembler, KeyRepository keyRepository, Parser<I18nCSVRepresentation> parser) {
+        this.fluentAssembler = fluentAssembler;
+        this.keyRepository = keyRepository;
+        this.parser = parser;
+    }
+
+    @JpaUnit("seed-i18n-domain")
+    @Transactional
+    @Override
+    public int importKeysWithTranslations(InputStream inputStream) {
+        List<I18nCSVRepresentation> i18nCSVRepresentations = parser.parse(inputStream, I18nCSVRepresentation.class);
+        for (I18nCSVRepresentation dto : i18nCSVRepresentations) {
+            Key key = fluentAssembler.merge(dto).into(Key.class).fromRepository().orFromFactory();
+            keyRepository.persist(key);
+        }
+        return i18nCSVRepresentations.size();
+    }
+}

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CSVParser.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CSVParser.java
@@ -5,8 +5,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest.internal.io;
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
 
+import org.seedstack.i18n.rest.internal.io.I18nCSVRepresentation;
 import org.seedstack.io.spi.AbstractTemplateParser;
 import org.seedstack.io.supercsv.SuperCsvTemplate;
 import org.slf4j.Logger;
@@ -26,17 +27,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.seedstack.i18n.rest.internal.io.I18nCSVTemplateLoader.KEY;
+import static org.seedstack.i18n.rest.internal.infrastructure.csv.I18nCSVTemplateLoader.KEY;
 
 /**
  * Custom parser for SuperCSV which allow to parse i18n files (containing dynamic columns).
  *
  * @author pierre.thirouin@ext.mpsa.com
  */
-@Named(I18nCSVParser.I18N_PARSER)
-class I18nCSVParser extends AbstractTemplateParser<SuperCsvTemplate, I18nCSVRepresentation> {
+@Named(CSVParser.I18N_PARSER)
+class CSVParser extends AbstractTemplateParser<SuperCsvTemplate, I18nCSVRepresentation> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(I18nCSVParser.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CSVParser.class);
     public static final String I18N_PARSER = "i18nSuperCSV";
 
     @Override

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CSVRowWriter.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CSVRowWriter.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest.internal.io;
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
 
 import org.seedstack.io.supercsv.SuperCsvTemplate;
 import org.slf4j.Logger;

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CsvAssembler.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CsvAssembler.java
@@ -5,11 +5,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest.internal.io;
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
 
 import org.seedstack.i18n.internal.domain.model.key.Key;
 import org.seedstack.i18n.internal.domain.model.key.Translation;
 import org.seedstack.business.assembler.BaseAssembler;
+import org.seedstack.i18n.rest.internal.io.I18nCSVRepresentation;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,7 +20,7 @@ import java.util.Map;
  *
  * @author pierre.thirouin@ext.mpsa.com
  */
-class DataAssembler extends BaseAssembler<Key, I18nCSVRepresentation> {
+class CsvAssembler extends BaseAssembler<Key, I18nCSVRepresentation> {
 
     @Override
     protected void doAssembleDtoFromAggregate(I18nCSVRepresentation targetDto, Key sourceEntity) {
@@ -34,22 +35,28 @@ class DataAssembler extends BaseAssembler<Key, I18nCSVRepresentation> {
 
     @Override
     protected void doMergeAggregateWithDto(Key targetKey, I18nCSVRepresentation sourceDto) {
-        for (Map.Entry<String, String> entry : sourceDto.getValue().entrySet()) {
-            String locale = entry.getKey();
-            String translation = entry.getValue();
+        if (sourceDto.getValue() != null) {
+            for (Map.Entry<String, String> entry : sourceDto.getValue().entrySet()) {
+                String locale = entry.getKey();
+                String translation = entry.getValue();
 
-            if (shouldUpdateTranslation(targetKey, locale, translation)) {
-                targetKey.addTranslation(locale, translation);
+                if (shouldUpdateTranslation(targetKey, locale, translation)) {
+                    targetKey.addTranslation(locale, translation);
+                }
             }
         }
     }
 
     private boolean shouldUpdateTranslation(Key targetKey, String locale, String translation) {
-        return !targetKey.isTranslated(locale) || translationHasChanged(targetKey, locale, translation);
+        return isNotBlank(translation) && translationHasChanged(targetKey, locale, translation);
+    }
+
+    private boolean isNotBlank(String translation) {
+        return translation != null && !translation.trim().equals("");
     }
 
     private boolean translationHasChanged(Key targetKey, String localeCode, String translationValue) {
         Translation translation = targetKey.getTranslation(localeCode);
-        return !translation.getValue().equals(translationValue);
+        return translation == null || !translation.getValue().equals(translationValue);
     }
 }

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/I18nCSVRenderer.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/I18nCSVRenderer.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest.internal.io;
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
 
 import org.seedstack.i18n.internal.domain.model.key.Key;
 import org.seedstack.io.spi.AbstractTemplateRenderer;

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/I18nCSVTemplateLoader.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/infrastructure/csv/I18nCSVTemplateLoader.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest.internal.io;
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
 
 import com.google.common.collect.Sets;
 import org.seedstack.i18n.rest.internal.locale.LocaleFinder;
@@ -63,6 +63,6 @@ public class I18nCSVTemplateLoader implements TemplateLoader {
 
     @Override
     public String templateParser() {
-        return I18nCSVParser.I18N_PARSER;
+        return CSVParser.I18N_PARSER;
     }
 }

--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/io/ImportService.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/io/ImportService.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.rest.internal.io;
+
+import org.seedstack.business.Service;
+
+import java.io.InputStream;
+
+/**
+ * A service which allows to import internationalization data.
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@Service
+public interface ImportService {
+
+    /**
+     * Imports a list of keys with their translations.
+     *
+     * @param inputStream the data to import
+     * @return the number of keys imported
+     */
+    int importKeysWithTranslations(InputStream inputStream);
+}

--- a/rest/src/test/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CSVImportServiceTest.java
+++ b/rest/src/test/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CSVImportServiceTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
+
+import com.google.common.collect.Lists;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.seedstack.business.assembler.FluentAssembler;
+import org.seedstack.business.assembler.dsl.MergeAggregateWithRepositoryThenFactoryProvider;
+import org.seedstack.i18n.internal.domain.model.key.Key;
+import org.seedstack.i18n.internal.domain.model.key.KeyRepository;
+import org.seedstack.i18n.rest.internal.io.I18nCSVRepresentation;
+import org.seedstack.io.Parser;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@RunWith(JMockit.class)
+public class CSVImportServiceTest {
+
+    private CSVImportService csvImportService;
+
+    @Mocked
+    private Parser<I18nCSVRepresentation> parser;
+    @Mocked
+    private KeyRepository keyRepository;
+    @Mocked
+    private FluentAssembler fluentAssembler;
+    @Mocked
+    private MergeAggregateWithRepositoryThenFactoryProvider mergeAggregate;
+    private InputStream inputStream;
+
+    @Before
+    public void setUp() throws Exception {
+        csvImportService = new CSVImportService(fluentAssembler, keyRepository, parser);
+        inputStream = new ByteArrayInputStream("".getBytes());
+    }
+
+    @Test
+    public void testImportEmptyInputStream() {
+        givenEmptyStream();
+        int importedKeys = csvImportService.importKeysWithTranslations(inputStream);
+        Assertions.assertThat(importedKeys).isEqualTo(0);
+    }
+
+    private void givenEmptyStream() {
+        new Expectations() {
+            {
+                parser.parse(inputStream, I18nCSVRepresentation.class);
+                result = Lists.newArrayList();
+            }
+        };
+    }
+
+    @Test
+    public void testImportKeys() {
+        givenParsedKeys(KeyBuilder.key("translation").with("fr", "tranduction").build());
+        int importedKeys = csvImportService.importKeysWithTranslations(inputStream);
+        Assertions.assertThat(importedKeys).isEqualTo(1);
+    }
+
+    private void givenParsedKeys(final I18nCSVRepresentation... representations) {
+        new Expectations() {
+            {
+                parser.parse(inputStream, I18nCSVRepresentation.class);
+                result = Lists.newArrayList(representations);
+
+                mergeAggregate.orFromFactory();
+                result = withAny(new Key("keyname"));
+            }
+        };
+    }
+
+    @Test
+    public void testImportedKeyWasPersisted() {
+        I18nCSVRepresentation key1 = KeyBuilder.key("translation").with("fr", "tranduction").build();
+        I18nCSVRepresentation key2 = KeyBuilder.key("translation").with("fr", "tranduction").build();
+        givenParsedKeys(key1, key2);
+
+        thenKeyWasPersisted(2);
+
+        csvImportService.importKeysWithTranslations(inputStream);
+    }
+
+    private void thenKeyWasPersisted(int numberOfKeys) {
+        new Expectations() {
+            {
+                keyRepository.persist(withAny(new Key("keyname")));
+                times = 2;
+            }
+        };
+    }
+
+    static class KeyBuilder {
+
+        private I18nCSVRepresentation i18nCSVRepresentation;
+
+        public KeyBuilder(String key) {
+            this.i18nCSVRepresentation = new I18nCSVRepresentation();
+            this.i18nCSVRepresentation.setKey(key);
+        }
+
+        public static KeyBuilder key(String key) {
+            return new KeyBuilder(key);
+        }
+
+        public KeyBuilder with(String locale, String translation) {
+            Map<String, String> translationsByLocale = this.i18nCSVRepresentation.getValue();
+            if (translationsByLocale == null) {
+                translationsByLocale = new HashMap<String, String>();
+            }
+            translationsByLocale.put(locale, translation);
+            this.i18nCSVRepresentation.setValue(translationsByLocale);
+            return this;
+        }
+
+        public I18nCSVRepresentation build() {
+            return i18nCSVRepresentation;
+        }
+    }
+}

--- a/rest/src/test/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CSVRowWriterTest.java
+++ b/rest/src/test/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CSVRowWriterTest.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest.internal.io;
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
 
 import org.apache.tomcat.util.http.fileupload.ByteArrayOutputStream;
 import org.assertj.core.api.Assertions;

--- a/rest/src/test/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CsvAssemblerTest.java
+++ b/rest/src/test/java/org/seedstack/i18n/rest/internal/infrastructure/csv/CsvAssemblerTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.seedstack.i18n.internal.domain.model.key.Key;
+import org.seedstack.i18n.rest.internal.infrastructure.csv.CSVImportServiceTest.KeyBuilder;
+import org.seedstack.i18n.rest.internal.io.I18nCSVRepresentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class CsvAssemblerTest {
+
+    private CsvAssembler underTest;
+    private Key key;
+
+    @Before
+    public void setUp() throws Exception {
+        underTest = new CsvAssembler();
+        key = new Key("foo");
+    }
+
+    @Test
+    public void testMergeWithEmptyRepresentation() {
+        I18nCSVRepresentation emptyRepresentation = new I18nCSVRepresentation();
+
+        underTest.mergeAggregateWithDto(key, emptyRepresentation);
+
+        assertThat(key.getEntityId()).as("check entityId don't change").isEqualTo("foo");
+    }
+
+    @Test
+    public void testMergeWithoutTranslations() {
+        underTest.mergeAggregateWithDto(key, KeyBuilder.key("foo").build());
+        assertThat(key.getEntityId()).as("check entityId don't change").isEqualTo("foo");
+    }
+
+    @Test
+    public void testMergeWithTranslation() {
+        I18nCSVRepresentation representation = KeyBuilder.key("foo")
+                .with("en", "translation").with("fr", "traduction").build();
+
+        underTest.mergeAggregateWithDto(key, representation);
+
+        assertThat(key.isTranslated("en")).isTrue();
+        assertThat(key.getTranslation("en").getValue()).isEqualTo("translation");
+        assertThat(key.isTranslated("fr")).isTrue();
+        assertThat(key.getTranslation("fr").getValue()).isEqualTo("traduction");
+    }
+
+    @Test
+    public void testMergeIgnoreMissingTranslations() {
+        I18nCSVRepresentation representation = KeyBuilder.key("foo")
+                .with("en", "").with("fr", null).build();
+
+        underTest.mergeAggregateWithDto(key, representation);
+
+        assertThat(key.isTranslated("en")).isFalse();
+        assertThat(key.isTranslated("fr")).isFalse();
+    }
+
+    @Test
+    public void testMergeUpdateTranslation() {
+        key.addTranslation("en", "translation");
+        I18nCSVRepresentation representation = KeyBuilder.key("foo")
+                .with("en", "newTranslation").build();
+
+        underTest.mergeAggregateWithDto(key, representation);
+
+        assertThat(key.getTranslation("en").getValue()).isEqualTo("newTranslation");
+    }
+
+    @Test
+    public void testAssemble() throws Exception {
+        I18nCSVRepresentation representation = underTest.assembleDtoFromAggregate(key);
+
+        assertThat(representation.getKey()).isEqualTo("foo");
+        assertThat(representation.getValue()).isNotNull();
+        assertThat(representation.getValue()).isEmpty();
+    }
+
+    @Test
+    public void testAssembleWithTranslations() throws Exception {
+        key.addTranslation("en", "translation");
+        key.addTranslation("fr", "traduction");
+
+        I18nCSVRepresentation representation = underTest.assembleDtoFromAggregate(key);
+
+        assertThat(representation.getValue()).containsEntry("en", "translation");
+        assertThat(representation.getValue()).containsEntry("fr", "traduction");
+    }
+}

--- a/rest/src/test/java/org/seedstack/i18n/rest/internal/infrastructure/csv/I18nCSVParserTest.java
+++ b/rest/src/test/java/org/seedstack/i18n/rest/internal/infrastructure/csv/I18nCSVParserTest.java
@@ -5,10 +5,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest.internal.io;
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.seedstack.i18n.rest.internal.io.I18nCSVRepresentation;
 import org.seedstack.io.supercsv.SuperCsvTemplate;
 
 import java.io.ByteArrayInputStream;
@@ -21,7 +22,7 @@ public class I18nCSVParserTest {
 
     private static final String FILE_CONTENT = "key;en;fr\nkey1;t9nEn;t9nFr\nkey2;t9nEn;t9nFr\n";
     private final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(FILE_CONTENT.getBytes());
-    private I18nCSVParser underTest = new I18nCSVParser();
+    private CSVParser underTest = new CSVParser();
 
     @Test(expected = NullPointerException.class)
     public void testNullInputStream() throws Exception {

--- a/rest/src/test/java/org/seedstack/i18n/rest/internal/infrastructure/csv/I18nCSVRendererTest.java
+++ b/rest/src/test/java/org/seedstack/i18n/rest/internal/infrastructure/csv/I18nCSVRendererTest.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.i18n.rest.internal.io;
+package org.seedstack.i18n.rest.internal.infrastructure.csv;
 
 import mockit.Deencapsulation;
 import mockit.Expectations;


### PR DESCRIPTION
When translations were missing in the CSV file, there were imported as null, which caused some `NullPointerException`.

It is now enforced in the domain that the translations can't be blank.