### PR TITLE
Fix media type issue on 409 error

### DIFF
--- a/rest/src/main/java/org/seedstack/i18n/rest/internal/shared/AlreadyExistException.java
+++ b/rest/src/main/java/org/seedstack/i18n/rest/internal/shared/AlreadyExistException.java
@@ -21,6 +21,10 @@ public class AlreadyExistException extends WebApplicationException {
 
     private static final long serialVersionUID = -4568375759076851959L;
 
+    public AlreadyExistException() {
+        super(Response.status(Response.Status.CONFLICT).build());
+    }
+
     /**
      * AlreadyExistException constructor.
      *


### PR DESCRIPTION
When trying to create an already existing key, don't return an error message with the 409 status code.